### PR TITLE
Add support for retries on requests with token.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/patrickdappollonio/homebrew-tap
 
-go 1.24
+go 1.24.1
 
 require (
+	github.com/patrickdappollonio/retryhttp v1.0.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/text v0.21.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/patrickdappollonio/retryhttp v0.0.0-20250331012006-ae828243033e h1:M05qJ7rHuVgXuOSkCjYFaZehxOooAuNXZEAxMJrDmYA=
+github.com/patrickdappollonio/retryhttp v0.0.0-20250331012006-ae828243033e/go.mod h1:lAXPoOmm1V+GghmqH8Pm8YvmGIz4iPB1Ew5qK5k0nZg=
+github.com/patrickdappollonio/retryhttp v1.0.0 h1:36Thew6FHKGjmW6MKfKyga7AeBAQNWUVZKXW/uThzl0=
+github.com/patrickdappollonio/retryhttp v1.0.0/go.mod h1:lAXPoOmm1V+GghmqH8Pm8YvmGIz4iPB1Ew5qK5k0nZg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=


### PR DESCRIPTION
Even on this repo workflow that uses a GitHub token to authenticate requests we're getting a slight rate limit every now and then. Considering the repo runs once daily it seems like a bad situation to have to wait another 24 hours to try again.

This PR adds the option to retry requests on 403s:

![image](https://github.com/user-attachments/assets/1805da5b-6385-4983-8c73-88da6a23a677)
